### PR TITLE
Update referal.rb to use pending new referer-parser gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 referer-parser-logstash-filter
 ==============================
 
-A referer parser filter for logstash based on snowplow gem
+A referer parser filter for logstash based on snowplow gem. This version requires version >0.2.2 of the gem.

--- a/referal.rb
+++ b/referal.rb
@@ -61,7 +61,7 @@ class LogStash::Filters::Referal < LogStash::Filters::Base
     referer = referer.first if referer.is_a? Array
 
     begin
-      referer_data = @parser.parse(referer)
+      referer_data = @parser.parse(referer) unless referer.nil? or referer.strip == ''
     rescue Exception => e
       @logger.error("Uknown error while parsing referer data", :exception => e, :field => @source, :event => event)
     end


### PR DESCRIPTION
I've completely rewritten the referer-parser gem for snowplow, and this updated filter will use the new API along with a few other minor tweaks I made. They have not yet merged it but will in the next day or two: https://github.com/snowplow/referer-parser/pull/80
